### PR TITLE
do not use ENTRYPOINT to enable use in gitlab ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ RUN apk add --update ca-certificates \
  && apk del --purge deps \
  && rm /var/cache/apk/*
 
-ENTRYPOINT ["kubectl"]
-CMD ["help"]
+CMD ["kubectl", "help"]
+


### PR DESCRIPTION
gitlab ci can run build steps in docker containers.
using entrypoints in images prevents them to be used as base for a build step environment.
this commit fixes:

```
Error: unknown command "sh" for "kubectl"

Did you mean this?
	set

Run 'kubectl --help' for usage.
Error: unknown command "sh" for "kubectl"

Did you mean this?
	set

Run 'kubectl --help' for usage.

ERROR: Build failed: exit code 1
```