### PR TITLE
Allow kubectl to have envsubst

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM loicmahieu/alpine-envsubst
 
 LABEL maintainer="Lachlan Evenson <lachlan.evenson@gmail.com>"
 


### PR DESCRIPTION
Useful when using CI to have environment variables used by kubectl