### PR TITLE
use latest release of k8s 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.docker.dockerfile="/Dockerfile"
 
-ENV KUBE_LATEST_VERSION="v1.13.0"
+ENV KUBE_LATEST_VERSION="v1.13.1"
 
 RUN apk add --update ca-certificates \
  && apk add --update -t deps curl \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![](https://images.microbadger.com/badges/commit/lachlanevenson/k8s-kubectl.svg)](http://microbadger.com/images/lachlanevenson/k8s-kubectl "Get your own commit badge on microbadger.com")
 
 # Supported tags and respective `Dockerfile` links
-* `v1.13.0`, `latest`    [(v1.13.0/Dockerfile)](https://github.com/lachie83/k8s-kubectl/blob/v1.13.0/Dockerfile)
+* `v1.13.1`, `latest`    [(v1.13.1/Dockerfile)](https://github.com/lachie83/k8s-kubectl/blob/v1.13.1/Dockerfile)
 * `v1.12.3`,    [(v1.12.3/Dockerfile)](https://github.com/lachie83/k8s-kubectl/blob/v1.12.2/Dockerfile)
 * `v1.11.5`,    [(v1.11.5/Dockerfile)](https://github.com/lachie83/k8s-kubectl/blob/v1.11.4/Dockerfile)
 * `v1.10.11`,   [(v1.10.11/Dockerfile)](https://github.com/lachie83/k8s-kubectl/blob/v1.10.9/Dockerfile)


### PR DESCRIPTION
1.13.1 has some critical azure provider fixes :). I am guessing this PR can be merged only after a 1.13.1 release tag is created .