### PR TITLE
Re-enable ppc64le docker image build

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -39,7 +39,7 @@ jobs:
       if: ${{ startsWith(github.ref, 'refs/heads/m') || startsWith(github.ref, 'refs/heads/v') }}
       uses: docker/build-push-action@v2
       with:
-        platforms: linux/amd64,linux/s390x,linux/arm64
+        platforms: linux/amd64,linux/s390x,linux/arm64,linux/ppc64le
         push: true
         tags: |
           ${{ github.ref != 'refs/heads/main' && steps.docker_meta.outputs.tags || '' }}


### PR DESCRIPTION
In latest image release(#152), `ppc64le` support was removed from `k8s-kubectl` image which is causing failures for few of `tektoncd/pipeline` tests and other projects which depend on this image. I tried a build and looks like the curl issue was intermittent and has been resolved.

Logs of latest GH action build from my fork: https://github.com/Siddhesh-Ghadi/k8s-kubectl/runs/3087280557?check_suite_focus=true#step:7:536

